### PR TITLE
Fix TypeError: Cannot read property 'bold' of undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "yeoman-generator": "~0.12.0"
+    "yeoman-generator": "~0.13.4"
   },
   "devDependencies": {
     "mocha": "~1.10.0"


### PR DESCRIPTION
Currently `yo bones` yield a 

```
TypeError: Cannot read property 'bold' of undefined
    at Object.<anonymous> (/usr/local/share/npm/lib/node_modules/generator-bones/node_modules/yeoman-generator/lib/util/common.js:5:56)
```

This fixes the issue
