### PR TITLE
add time-grunt

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -15,6 +15,8 @@ var mountFolder = function (connect, dir) {
 module.exports = function (grunt) {
     // load all grunt tasks
     require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+    // show elapsed time at the end
+    require('time-grunt')(grunt);
 
     // configurable paths
     var yeomanConfig = {

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -24,7 +24,8 @@
     "grunt-grunticon": "~0.3.3",
     "assemble": "~0.4.1",
     "matchdep": "~0.1.1",
-    "connect-livereload": "~0.2.0"
+    "connect-livereload": "~0.2.0",
+    "time-grunt": "~0.1.1"
   },
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
[time-grunt](https://github.com/sindresorhus/time-grunt) displays the elapsed execution time of grunt tasks. We're using it in [generator-webapp](https://github.com/yeoman/generator-webapp/blob/master/app/templates/Gruntfile.js#L11-L12).
